### PR TITLE
Commit 4bbab45c introduced an issue

### DIFF
--- a/MiHomeLib/MiHome.cs
+++ b/MiHomeLib/MiHome.cs
@@ -135,6 +135,7 @@ namespace MiHomeLib
 
         private void ProcessReport(ResponseCommand cmd)
         {
+            if (_gateway != null && cmd.Sid == _gateway.Sid) return;
             GetOrAddDeviceByCommand(cmd).ParseData(cmd.Data);
         }
 


### PR DESCRIPTION
Calling Gateway.EnableLight results to report message from the gateway however it fires an exception in the new MiHome.GetOrAddDeviceByCommand method. See 4bbab45c.