### PR TITLE
Calling Gateway.EnableLight results to report message from the gateway however it fires an exception in the new MiHome.GetOrAddDeviceByCommand method.

### DIFF
--- a/MiHomeLib/Commands/GatewayLightCommand.cs
+++ b/MiHomeLib/Commands/GatewayLightCommand.cs
@@ -1,19 +1,17 @@
 ﻿namespace MiHomeLib.Commands
 {
-    internal class GatewayLightCommand: Command
+    internal class GatewayLightCommand : Command
     {
         private readonly long _rgb;
-        private readonly int _illumination;
 
-        public GatewayLightCommand(long rgb, int illumination)
+        public GatewayLightCommand(long rgb)
         {
             _rgb = rgb;
-            _illumination = illumination;
         }
 
         public override string ToString()
         {
-            return $"{{\"rgb\":{_rgb},\"illumination\":{_illumination}}}";
+            return $"{{\"rgb\":{_rgb}}}";
         }
     }
 }

--- a/MiHomeLib/Devices/Gateway.cs
+++ b/MiHomeLib/Devices/Gateway.cs
@@ -43,18 +43,18 @@ namespace MiHomeLib.Devices
             return $"Rgb: {Rgb}, Illumination: {Illumination}, ProtoVersion: {ProtoVersion}";
         }
 
-        public void EnableLight(byte r = 255, byte g = 255, byte b = 255, int illumination = 1000)
+        public void EnableLight(byte r = 255, byte g = 255, byte b = 255, int brightness = 100)
         {
-            var rgb = 0xFF000000 | r << 16 | g << 8 | b; // found this trick from chinise gateway docs 
+            var rgb = (uint)brightness << 24 | r << 16 | g << 8 | b;
 
-            if (illumination < 300 || illumination > 1300) throw new ArgumentException("Illumination must be in range 300 - 1300");
+            if (brightness < 1 || brightness > 100) throw new ArgumentException("Brightness must be in range 1 - 100");
 
-            _transport.SendWriteCommand(Sid, Type, new GatewayLightCommand(rgb, illumination));
+            _transport.SendWriteCommand(Sid, Type, new GatewayLightCommand(rgb));
         }
 
         public void DisableLight()
         {
-            _transport.SendWriteCommand(Sid, Type, new GatewayLightCommand(0, 0));
+            _transport.SendWriteCommand(Sid, Type, new GatewayLightCommand(0));
         }
 
         public void StartPlayMusic(int midNo = 0)

--- a/MiHomeLib/MiHome.cs
+++ b/MiHomeLib/MiHome.cs
@@ -135,7 +135,6 @@ namespace MiHomeLib
 
         private void ProcessReport(ResponseCommand cmd)
         {
-            if (_gateway != null && cmd.Sid == _gateway.Sid) return;
             GetOrAddDeviceByCommand(cmd).ParseData(cmd.Data);
         }
 
@@ -159,6 +158,8 @@ namespace MiHomeLib
 
         private MiHomeDevice GetOrAddDeviceByCommand(ResponseCommand cmd)
         {
+            if (_gateway != null && cmd.Sid == _gateway.Sid) return _gateway;
+
             if (_devicesList.ContainsKey(cmd.Sid)) return _devicesList[cmd.Sid];
 
             var device = _devicesMap[cmd.Model](cmd.Sid);


### PR DESCRIPTION
The previous commit wasn't complete due to introducing a new issue. When we set up the gateway light it replies with report message giving us new gateway settings. However the previous commit just returned in that case. The new code has two benefits: first it returns _gateway so the gateway properties will update by report message, second it prevents the exception as the previous commit did.

Please accept this pull request to complete the change started by the previous commit.