### PR TITLE
Fix udp solely binding for XiaomiGateway2

### DIFF
--- a/MiHomeLib/Transport/UdpTransport.cs
+++ b/MiHomeLib/Transport/UdpTransport.cs
@@ -23,7 +23,9 @@ namespace MiHomeLib
             _multicastAddress = multicastAddress;
             _serverPort = serverPort;
         
-            _udpClient = new UdpClient(new IPEndPoint(IPAddress.Any, _serverPort));
+            _udpClient = new UdpClient();
+            _udpClient.Client.SetSocketOption(SocketOptionLevel.Socket, SocketOptionName.ReuseAddress, true);
+            _udpClient.Client.Bind(new IPEndPoint(IPAddress.Any, _serverPort));
             _udpClient.JoinMulticastGroup(IPAddress.Parse(_multicastAddress));
         }
 


### PR DESCRIPTION
Annoying bug was found that prevented running multiple instances/scripts listening udp multicast traffic simultaneously.
This PR should fix it