### PR TITLE
Small codebase improvements

### DIFF
--- a/MiHomeLib/Contracts/IDevicesDiscoverer.cs
+++ b/MiHomeLib/Contracts/IDevicesDiscoverer.cs
@@ -2,8 +2,34 @@ using System.Collections.Generic;
 
 namespace MiHomeLib.Contracts;
 
+public class BleDeviceInfo
+{
+    public BleDeviceInfo(string did, int pdid, string mac)
+    {
+        Did = did;
+        Pdid = pdid;
+        Mac = mac;
+    }
+
+    public string Did { get; }
+    public int Pdid { get; }
+    public string Mac { get; }
+}
+
+public class ZigBeeDeviceInfo
+{
+    public ZigBeeDeviceInfo(string did, string model)
+    {
+        Did = did;
+        Model = model;
+    }
+
+    public string Did { get; }
+    public string Model { get; }
+}
+
 public interface IDevicesDiscoverer
 {
-    List<(string did, int pdid, string mac)> DiscoverBleDevices();
-    List<(string did, string model)> DiscoverZigBeeDevices();
+    List<BleDeviceInfo> DiscoverBleDevices();
+    List<ZigBeeDeviceInfo> DiscoverZigBeeDevices();
 }

--- a/MiHomeLib/Contracts/IMiioTransport.cs
+++ b/MiHomeLib/Contracts/IMiioTransport.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 
-namespace MiHomeLib.Transport;
+namespace MiHomeLib.Contracts;
 
 public interface IMiioTransport: IDisposable
 {

--- a/MiHomeLib/Contracts/IMqttTransport.cs
+++ b/MiHomeLib/Contracts/IMqttTransport.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace MiHomeLib.Transport;
+namespace MiHomeLib.Contracts;
 
 public interface IMqttTransport : IDisposable
 {

--- a/MiHomeLib/DeviceTypeScanner.cs
+++ b/MiHomeLib/DeviceTypeScanner.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace MiHomeLib;
+
+/// <summary>
+/// Scans the executing assembly for device types that inherit from specified base types
+/// and extracts their MODEL static field values via reflection.
+/// Used by both MqttGatewayBase and XiaomiGateway2 to discover supported device types.
+/// </summary>
+internal static class DeviceTypeScanner
+{
+    private static readonly BindingFlags StaticPublic = BindingFlags.Public | BindingFlags.Static;
+
+    /// <summary>
+    /// Find all non-abstract device types inheriting from TBase and their MODEL values
+    /// </summary>
+    public static IEnumerable<(Type type, string model)> FindDeviceTypes<TBase>() where TBase : class
+    {
+        return FindDeviceTypes(typeof(TBase));
+    }
+
+    /// <summary>
+    /// Find all non-abstract device types inheriting from any of the specified base types and their MODEL values
+    /// </summary>
+    public static IEnumerable<(Type type, string model)> FindDeviceTypes(params Type[] baseTypes)
+    {
+        return Assembly
+            .GetExecutingAssembly()
+            .GetTypes()
+            .Where(x => x.IsClass && !x.IsAbstract && baseTypes.Any(bt => x.IsSubclassOf(bt)))
+            .Select(type => (type, model: type.GetField("MODEL", StaticPublic).GetValue(type).ToString()));
+    }
+
+    /// <summary>
+    /// Read a static field value from a device type
+    /// </summary>
+    public static T GetStaticField<T>(Type type, string fieldName)
+    {
+        return (T)type.GetField(fieldName, StaticPublic).GetValue(type);
+    }
+}

--- a/MiHomeLib/GatewaySubDeviceBase.cs
+++ b/MiHomeLib/GatewaySubDeviceBase.cs
@@ -1,0 +1,33 @@
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace MiHomeLib;
+
+/// <summary>
+/// Common base class for all gateway sub-devices (both XiaomiGateway2 and MqttGateway hierarchies).
+/// Contains shared properties and behavior: logging, last message timestamp, device identification.
+/// </summary>
+public abstract class GatewaySubDeviceBase(ILoggerFactory loggerFactory)
+{
+    protected readonly ILogger _logger = loggerFactory.CreateLogger<GatewaySubDeviceBase>();
+
+    /// <summary>
+    /// Primary device identifier (Did for MqttGateway devices, Sid for XiaomiGateway2 devices)
+    /// </summary>
+    public abstract string DeviceId { get; }
+
+    /// <summary>
+    /// Timestamp of the last received message from this device
+    /// </summary>
+    public DateTime LastTimeMessageReceived { get; internal set; }
+
+    /// <summary>
+    /// Parse incoming data payload from the gateway
+    /// </summary>
+    protected internal abstract void ParseData(string command);
+
+    /// <summary>
+    /// Format base device info string with market model, model and device identifier
+    /// </summary>
+    protected virtual string GetBaseInfo(string marketModel, string model) => $"Device: {marketModel} {model} {DeviceId}, ";
+}

--- a/MiHomeLib/MiioDevices/MiioDevice.cs
+++ b/MiHomeLib/MiioDevices/MiioDevice.cs
@@ -5,7 +5,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading;
 using System.Threading.Tasks;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MiioDevices;
 
@@ -17,6 +17,16 @@ public abstract class MiioDevice(IMiioTransport miioTransport, int initialIdExte
         PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
     };
     protected readonly IMiioTransport _miioTransport = miioTransport;
+
+    /// <summary>
+    /// Run an async Task-returning function synchronously, avoiding boilerplate
+    /// </summary>
+    protected static void RunSync(Func<Task> asyncFunc) => asyncFunc().ConfigureAwait(false).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Run an async Task&lt;T&gt;-returning function synchronously, avoiding boilerplate
+    /// </summary>
+    protected static T RunSync<T>(Func<Task<T>> asyncFunc) => asyncFunc().ConfigureAwait(false).GetAwaiter().GetResult();
 
     protected void CheckMessage(string response, string errorMessage)
     {
@@ -70,6 +80,7 @@ public abstract class MiioDevice(IMiioTransport miioTransport, int initialIdExte
     protected string RepeatMessageIfTimeout(Func<string, string> func, string msg, int times = 3)
     {
         var error = string.Empty;
+        Exception lastException = null;
 
         for (int i = 0; i < times; i++)
         {
@@ -83,19 +94,22 @@ public abstract class MiioDevice(IMiioTransport miioTransport, int initialIdExte
                 {
                     error = json["error"].ToString();
                     Interlocked.Increment(ref _initialId);
-                    var newMsg = JsonNode.Parse(msg)["id"];
-                    newMsg["id"] = _initialId;
-                    msg = newMsg.ToString();
+                    var msgJson = JsonNode.Parse(msg);
+                    msgJson["id"] = _initialId;
+                    msg = msgJson.ToJsonString();
                     continue;
                 }
 
                 return response;
 
             }
-            catch (Exception) { }
+            catch (Exception ex)
+            {
+                lastException = ex;
+            }
         }
 
-        throw new Exception($"No response for msg -> '{msg}' after {times} attempts, error '{error}'");
+        throw new Exception($"No response for msg -> '{msg}' after {times} attempts, error '{error}'", lastException);
     }
     protected string[] GetProps(params string[] props)
     {
@@ -119,5 +133,5 @@ public abstract class MiioDevice(IMiioTransport miioTransport, int initialIdExte
 
         return Convert.ToInt32(device.type + device.serial, 16).ToString();
     }
-    public void Dispose() => _miioTransport?.Dispose();
+    public virtual void Dispose() => _miioTransport?.Dispose();
 }

--- a/MiHomeLib/MiioDevices/MiioTransport.cs
+++ b/MiHomeLib/MiioDevices/MiioTransport.cs
@@ -7,7 +7,7 @@ using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 [assembly: InternalsVisibleTo("MiHomeUnitTests")]
 
@@ -65,7 +65,7 @@ internal class MiioTransport : IMiioTransport
                 discoveredDevices.Add((ip, packet.GetDeviceType(), packet.GetSerial(), packet.GetChecksum()));
             }
         }
-        catch { } // Normal situation, no more data in socket
+        catch (SocketException) { } // Expected: socket receive timeout means no more devices to discover
 
         socket.Close();
 

--- a/MiHomeLib/MiioDevices/MijiaSmartSocket2China.cs
+++ b/MiHomeLib/MiioDevices/MijiaSmartSocket2China.cs
@@ -1,7 +1,7 @@
 ﻿// Partial support for this device has been implemented on top of https://home.miot-spec.com/spec/chuangmi.plug.212a01
 // Your contributions are appreciated
 using System;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MiioDevices;
 

--- a/MiHomeLib/MiioDevices/MiotGenericDevice.cs
+++ b/MiHomeLib/MiioDevices/MiotGenericDevice.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MiioDevices;
 

--- a/MiHomeLib/MiioDevices/XiaomiAirHumidifierV1.cs
+++ b/MiHomeLib/MiioDevices/XiaomiAirHumidifierV1.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MiioDevices;
 

--- a/MiHomeLib/MiioDevices/XiaomiRobotVacuumCleanerV1.cs
+++ b/MiHomeLib/MiioDevices/XiaomiRobotVacuumCleanerV1.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MiioDevices;
 

--- a/MiHomeLib/MiioDevices/XiaomiRobotVacuumMop3C.cs
+++ b/MiHomeLib/MiioDevices/XiaomiRobotVacuumMop3C.cs
@@ -2,7 +2,7 @@
 // Your contributions are appreciated
 using System;
 using System.Linq;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MiioDevices;
 

--- a/MiHomeLib/MiioDevices/XiaomiSmartAirPurifier4Lite.cs
+++ b/MiHomeLib/MiioDevices/XiaomiSmartAirPurifier4Lite.cs
@@ -2,7 +2,7 @@
 // Your contributions are appreciated
 using System;
 using System.Globalization;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MiioDevices;
 

--- a/MiHomeLib/MiioDevices/XiaomiSmartPlug2Euro.cs
+++ b/MiHomeLib/MiioDevices/XiaomiSmartPlug2Euro.cs
@@ -1,7 +1,7 @@
 ﻿// Partial support for this device has been implemented on top of https://home.miot-spec.com/spec/cuco.plug.v2eur
 // Your contributions are appreciated
 using System;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MiioDevices;
 

--- a/MiHomeLib/MqttGateway/ActionProcessors/AsyncBleEventMethodProcessor.cs
+++ b/MiHomeLib/MqttGateway/ActionProcessors/AsyncBleEventMethodProcessor.cs
@@ -30,13 +30,13 @@ public class AsyncBleEventMethodProcessor(Dictionary<string, MqttGatewaySubDevic
 
         var did = dev["did"].ToString();
 
-        if (!_devices.ContainsKey(did))
+        if (!_devices.TryGetValue(did, out var device))
         {
             _logger.LogWarning($"Device with did '{did}' is unknown. Processing is skipped");
             return;
         }
 
-        _devices[did].LastTimeMessageReceived = parms["gwts"].GetValue<double>().UnixSecondsToDateTime();
-        _devices[did].ParseData(parms.ToString());
+        device.LastTimeMessageReceived = parms["gwts"].GetValue<double>().UnixSecondsToDateTime();
+        device.ParseData(parms.ToString());
     }
 }

--- a/MiHomeLib/MqttGateway/ActionProcessors/EventOccuredMethodProcessor.cs
+++ b/MiHomeLib/MqttGateway/ActionProcessors/EventOccuredMethodProcessor.cs
@@ -30,13 +30,13 @@ public class EventOccuredMethodProcessor(Dictionary<string, MqttGatewaySubDevice
 
         var did = parms["did"].ToString();
         
-        if (!_devices.ContainsKey(did))
+        if (!_devices.TryGetValue(did, out var device))
         {
             _logger.LogWarning($"Device with did '{did}' is unknown. Processing is skipped");
             return;
         }
         
-        _devices[did].LastTimeMessageReceived = DateTime.Now;
-        _devices[did].ParseData(parms.ToString());
+        device.LastTimeMessageReceived = DateTime.Now;
+        device.ParseData(parms.ToString());
     }
 }

--- a/MiHomeLib/MqttGateway/ActionProcessors/ZigbeeHeartBeatCommandProcessor.cs
+++ b/MiHomeLib/MqttGateway/ActionProcessors/ZigbeeHeartBeatCommandProcessor.cs
@@ -32,10 +32,10 @@ public class ZigbeeHeartBeatCommandProcessor(Dictionary<string, MqttGatewaySubDe
 
         var did = data[0]["did"].GetString();
 
-        if (_devices.ContainsKey(did))
+        if (_devices.TryGetValue(did, out var device))
         {
-            _devices[did].LastTimeMessageReceived = data[0]["time"].GetDouble().UnixMilliSecondsToDateTime();
-            (_devices[did] as ZigBeeDevice).ParseData(data[0]["res_list"].ToString());
+            device.LastTimeMessageReceived = data[0]["time"].GetDouble().UnixMilliSecondsToDateTime();
+            (device as ZigBeeDevice).ParseData(data[0]["res_list"].ToString());
         }
         else
         {

--- a/MiHomeLib/MqttGateway/ActionProcessors/ZigbeeReportCommandProcessor.cs
+++ b/MiHomeLib/MqttGateway/ActionProcessors/ZigbeeReportCommandProcessor.cs
@@ -21,10 +21,10 @@ public class ZigbeeReportCommandProcessor: IActionProcessor
     {
         var did = json["did"].ToString();
 
-        if (_devices.ContainsKey(did))
+        if (_devices.TryGetValue(did, out var device))
         {
-            _devices[did].LastTimeMessageReceived = json["time"].GetValue<double>().UnixMilliSecondsToDateTime();
-            (_devices[did] as ZigBeeDevice).ParseData((json["mi_spec"] is not null ? json["mi_spec"] : json["params"]).ToString());
+            device.LastTimeMessageReceived = json["time"].GetValue<double>().UnixMilliSecondsToDateTime();
+            (device as ZigBeeDevice).ParseData((json["mi_spec"] is not null ? json["mi_spec"] : json["params"]).ToString());
         }
         else
         {

--- a/MiHomeLib/MqttGateway/AqaraHubE1China.cs
+++ b/MiHomeLib/MqttGateway/AqaraHubE1China.cs
@@ -6,7 +6,7 @@ using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using MiHomeLib.Contracts;
 using MiHomeLib.MiioDevices;
-using MiHomeLib.Transport;
+
 
 namespace MiHomeLib.MqttGateway;
 

--- a/MiHomeLib/MqttGateway/CommonDevicesDiscoverer.cs
+++ b/MiHomeLib/MqttGateway/CommonDevicesDiscoverer.cs
@@ -87,9 +87,9 @@ internal class CommonDevicesDiscoverer(string host, int port, string login, stri
 
         return Convert.FromBase64String(data);
     }
-    public List<(string did, int pdid, string mac)> DiscoverBleDevices()
+    public List<BleDeviceInfo> DiscoverBleDevices()
     {
-        var bleDevicesList = new List<(string did, int pdid, string mac)>();
+        var bleDevicesList = new List<BleDeviceInfo>();
 
         var tmpName = Path.GetTempFileName();
         File.WriteAllBytes(tmpName, ReadFileByPath(blePath));
@@ -107,19 +107,19 @@ internal class CommonDevicesDiscoverer(string host, int port, string login, stri
             var mac = reader.GetString(0);
             var pdid = reader.GetInt32(1);
             var did = reader.GetString(2);
-            bleDevicesList.Add((did, pdid, mac));
+            bleDevicesList.Add(new BleDeviceInfo(did, pdid, mac));
         }
 
         File.Delete(tmpName);
 
         return bleDevicesList;
     }
-    public List<(string did, string model)> DiscoverZigBeeDevices()
+    public List<ZigBeeDeviceInfo> DiscoverZigBeeDevices()
     {
         var json = JsonNode.Parse(Encoding.ASCII.GetString(ReadFileByPath(zigbeePath)));
 
         return [.. json["devInfo"]
                 .AsArray()
-                .Select(x => (x["did"].ToString(), x["model"].ToString()))];
+                .Select(x => new ZigBeeDeviceInfo(x["did"].ToString(), x["model"].ToString()))];
     }
 }

--- a/MiHomeLib/MqttGateway/Devices/AqaraDualWirelessRelayCN.cs
+++ b/MiHomeLib/MqttGateway/Devices/AqaraDualWirelessRelayCN.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MqttGateway.Devices;
 

--- a/MiHomeLib/MqttGateway/Devices/AqaraT1WithNeutral.cs
+++ b/MiHomeLib/MqttGateway/Devices/AqaraT1WithNeutral.cs
@@ -4,7 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MqttGateway.Devices;
 
@@ -85,8 +85,8 @@ public class AqaraT1WithNeutral : ZigBeeManageableDevice
         {
             var key = (prop["siid"].GetValue<int>(), prop["piid"].GetValue<int>());
             
-            if(_actions.ContainsKey(key))
-                 _actions[key](prop["value"]);
+            if(_actions.TryGetValue(key, out var action))
+                 action(prop["value"]);
         }
     }
     public void PowerOn() => SendWriteCommand(STATE_RES, 1);

--- a/MiHomeLib/MqttGateway/Devices/AqaraVibrationSensor.cs
+++ b/MiHomeLib/MqttGateway/Devices/AqaraVibrationSensor.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MqttGateway.Devices;
 

--- a/MiHomeLib/MqttGateway/Devices/BleDevice.cs
+++ b/MiHomeLib/MqttGateway/Devices/BleDevice.cs
@@ -21,9 +21,9 @@ public abstract class BleDevice(string did, ILoggerFactory loggerFactory) : Mqtt
         {
             var eid = evt["eid"].GetValue<int>();
             
-            if(EidToActions.ContainsKey(eid))
+            if(EidToActions.TryGetValue(eid, out var action))
             {
-                EidToActions[eid](evt["edata"].ToString().ToLower());
+                action(evt["edata"].ToString().ToLower());
             }
             else
             {

--- a/MiHomeLib/MqttGateway/Devices/MqttGatewaySubDevice.cs
+++ b/MiHomeLib/MqttGateway/Devices/MqttGatewaySubDevice.cs
@@ -3,12 +3,9 @@ using Microsoft.Extensions.Logging;
 
 namespace MiHomeLib.MqttGateway.Devices;
 
-public abstract class MqttGatewaySubDevice(string did, ILoggerFactory loggerFactory)
+public abstract class MqttGatewaySubDevice(string did, ILoggerFactory loggerFactory) : GatewaySubDeviceBase(loggerFactory)
 {
-    public string Did { get; } = did;    
+    public string Did { get; } = did;
+    public override string DeviceId => Did;
     public override string ToString() => $"Did: {Did}";
-    public DateTime LastTimeMessageReceived { get; internal set; }
-    protected readonly ILogger _logger = loggerFactory.CreateLogger<MqttGatewaySubDevice>();    
-    protected internal abstract void ParseData(string command);    
-    protected virtual string GetBaseInfo(string marketModel, string model) => $"Device: {marketModel} {model} {Did}, ";
 }

--- a/MiHomeLib/MqttGateway/Devices/PtxWirelessSwitchBle.cs
+++ b/MiHomeLib/MqttGateway/Devices/PtxWirelessSwitchBle.cs
@@ -42,9 +42,9 @@ public class PtxWirelessSwitchBle : BleDevice
 
         if (
             (siid == CLICK_SIID || siid == LOW_BATTERY_SIID)
-            && EidToActions.ContainsKey(siid) && Enum.IsDefined(typeof(ClickArg), eiid))
+            && EidToActions.TryGetValue(siid, out var action) && Enum.IsDefined(typeof(ClickArg), eiid))
         {
-            EidToActions[siid](eiid.ToString());
+            action(eiid.ToString());
         }
     }
     /// <summary>

--- a/MiHomeLib/MqttGateway/Devices/XiaomiHoneywellSmokeDetector.cs
+++ b/MiHomeLib/MqttGateway/Devices/XiaomiHoneywellSmokeDetector.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MqttGateway.Devices;
 public class XiaomiHoneywellSmokeDetector : ZigBeeManageableDevice

--- a/MiHomeLib/MqttGateway/Devices/XiaomiMiSmartPowerPlugCN.cs
+++ b/MiHomeLib/MqttGateway/Devices/XiaomiMiSmartPowerPlugCN.cs
@@ -3,7 +3,7 @@ using System.Linq;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MqttGateway.Devices;
 

--- a/MiHomeLib/MqttGateway/Devices/ZigBeeDevice.cs
+++ b/MiHomeLib/MqttGateway/Devices/ZigBeeDevice.cs
@@ -59,13 +59,13 @@ public abstract class ZigBeeDevice : MqttGatewaySubDevice
 
         foreach (var prop in listProps)
         {
-            if (prop.ContainsKey(RES_NAME) && Actions.ContainsKey(prop[RES_NAME].GetString()))
+            if (prop.TryGetValue(RES_NAME, out var resName) && Actions.TryGetValue(resName.GetString(), out var action))
             {
-                Actions[prop[RES_NAME].ToString()](prop[VALUE]);
+                action(prop[VALUE]);
             }
             else
             {
-                _logger.LogWarning($"Property '{prop[RES_NAME].GetString()}' is not supported for this device yet. Please contribute to support.");
+                _logger.LogWarning($"Property '{(prop.ContainsKey(RES_NAME) ? prop[RES_NAME].GetString() : "unknown")}' is not supported for this device yet. Please contribute to support.");
             }
         }
     }

--- a/MiHomeLib/MqttGateway/Devices/ZigBeeManageableBatteryDevice.cs
+++ b/MiHomeLib/MqttGateway/Devices/ZigBeeManageableBatteryDevice.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.Logging;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MqttGateway.Devices;
 

--- a/MiHomeLib/MqttGateway/Devices/ZigBeeManageableDevice.cs
+++ b/MiHomeLib/MqttGateway/Devices/ZigBeeManageableDevice.cs
@@ -1,5 +1,5 @@
 using Microsoft.Extensions.Logging;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MqttGateway.Devices;
 

--- a/MiHomeLib/MqttGateway/MqttDotNetTransport.cs
+++ b/MiHomeLib/MqttGateway/MqttDotNetTransport.cs
@@ -1,6 +1,6 @@
 using System;
 using Microsoft.Extensions.Logging;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 using MQTTnet;
 using MQTTnet.Client;
 

--- a/MiHomeLib/MqttGateway/MqttGatewayBase.cs
+++ b/MiHomeLib/MqttGateway/MqttGatewayBase.cs
@@ -4,9 +4,9 @@ using System.Text.Json.Nodes;
 using System.Collections.Generic;
 using Microsoft.Extensions.Logging.Abstractions;
 using System.Linq;
-using System.Reflection;
+
 using MiHomeLib.MiioDevices;
-using MiHomeLib.Transport;
+
 using System.Threading.Tasks;
 using MiHomeLib.Contracts;
 using MiHomeLib.MqttGateway.ActionProcessors;
@@ -42,15 +42,9 @@ public abstract class MqttGatewayBase : MiotGenericDevice, IDisposable
         _mqttTransport = mqttTransport;
         _devicesDiscoverer = devicesDiscoverer;
 
-        // Building map of the supported devices via reflection props 
-        foreach (Type type in Assembly
-            .GetExecutingAssembly()
-            .GetTypes()
-            .Where(x => x.IsClass && !x.IsAbstract && (x.IsSubclassOf(typeof(ZigBeeDevice)) || x.IsSubclassOf(typeof(BleDevice)))))
+        // Building map of the supported devices via reflection
+        foreach (var (type, model) in DeviceTypeScanner.FindDeviceTypes(typeof(ZigBeeDevice), typeof(BleDevice)))
         {
-            var bindFlags = BindingFlags.Public | BindingFlags.Static;
-            var model = type.GetField("MODEL", bindFlags).GetValue(type).ToString();
-
             MqttGatewaySubDevice addDevice(string did) =>
                 type.IsSubclassOf(typeof(ZigBeeManageableDevice)) || type.IsSubclassOf(typeof(ZigBeeManageableBatteryDevice)) ?
                     Activator.CreateInstance(type, did, _mqttTransport, _loggerFactory) as MqttGatewaySubDevice :
@@ -60,7 +54,7 @@ public abstract class MqttGatewayBase : MiotGenericDevice, IDisposable
 
             if (!type.IsSubclassOf(typeof(BleDevice))) continue;
 
-            _pdidToModel.Add((int)type.GetField("PDID", bindFlags).GetValue(type), model);
+            _pdidToModel.Add(DeviceTypeScanner.GetStaticField<int>(type, "PDID"), model);
         }
     }
     public void DiscoverDevices()
@@ -87,13 +81,13 @@ public abstract class MqttGatewayBase : MiotGenericDevice, IDisposable
             }
             
 
-            if (!_supportedActionProcessors.ContainsKey(action))
+            if (!_supportedActionProcessors.TryGetValue(action, out var processor))
             {
                 _logger.LogWarning($"Command/Method '{action}' is unknown. Please contribute to support.");
                 return;
             }
 
-            _supportedActionProcessors[action].ProcessMessage(json);
+            processor.ProcessMessage(json);
         };
 
         DiscoverZigbeeDevices().Wait();
@@ -112,16 +106,16 @@ public abstract class MqttGatewayBase : MiotGenericDevice, IDisposable
 
         foreach (var device in zigbeeDeviceList)
         {
-            var model = device.model;
+            var model = device.Model;
 
-            if (!_supportedModels.ContainsKey(model))
+            if (!_supportedModels.TryGetValue(model, out var factory))
             {
                 _logger.LogWarning($"Device '{model}' is not supported yet. Please contribute to support");
                 continue;
             }
 
-            var did = device.did;
-            var mihomeDevice = _supportedModels[model](did) as ZigBeeDevice;
+            var did = device.Did;
+            var mihomeDevice = factory(did) as ZigBeeDevice;
 
             _logger.LogInformation($"Device '{model}' with did '{did}' has been discovered");
 
@@ -175,18 +169,17 @@ public abstract class MqttGatewayBase : MiotGenericDevice, IDisposable
     }
     protected virtual async Task DiscoverBleDevices()
     {
-        foreach (var (did, pdid, mac) in _devicesDiscoverer.DiscoverBleDevices())
+        foreach (var device in _devicesDiscoverer.DiscoverBleDevices())
         {
-            if (!_pdidToModel.ContainsKey(pdid))
+            if (!_pdidToModel.TryGetValue(device.Pdid, out var model))
             {
-                _logger.LogWarning($"Device with pdid '{pdid}' is not supported yet. Please contribute to support.");
+                _logger.LogWarning($"Device with pdid '{device.Pdid}' is not supported yet. Please contribute to support.");
                 continue;
             }
 
-            var model = _pdidToModel[pdid];
-            var mihomeDevice = _supportedModels[model](did) as BleDevice;
+            var mihomeDevice = _supportedModels[model](device.Did) as BleDevice;
 
-            mihomeDevice.Mac = DecodeMacAddress(mac);
+            mihomeDevice.Mac = DecodeMacAddress(device.Mac);
 
             _devices.Add(mihomeDevice.Did, mihomeDevice);
             _logger.LogInformation($"Device '{model}' with did '{mihomeDevice.Did}' has been successfully discovered");
@@ -223,15 +216,13 @@ public abstract class MqttGatewayBase : MiotGenericDevice, IDisposable
     public List<MqttGatewaySubDevice> GetDevices() => [.. _devices.Values];
     public T GetDeviceByDid<T>(string did) where T : MqttGatewaySubDevice
     {
-        if (!_devices.ContainsKey(did)) return null;
+        if (!_devices.TryGetValue(did, out var device)) return null;
 
-        var device = _devices[did];
+        if (device is not T typed) return null;
 
-        if (device is not T) return null;
-
-        return device as T;
+        return typed;
     }
-    public new void Dispose()
+    public override void Dispose()
     {
         _mqttTransport?.Dispose();
         base.Dispose();

--- a/MiHomeLib/MqttGateway/MultimodeGateway.cs
+++ b/MiHomeLib/MqttGateway/MultimodeGateway.cs
@@ -4,7 +4,7 @@ using System;
 using System.Collections.Generic;
 using MiHomeLib.Contracts;
 using MiHomeLib.MiioDevices;
-using MiHomeLib.Transport;
+
 
 namespace MiHomeLib.MqttGateway;
 

--- a/MiHomeLib/MqttGateway/MultimodeGateway2Base.cs
+++ b/MiHomeLib/MqttGateway/MultimodeGateway2Base.cs
@@ -1,7 +1,7 @@
 using System;
 using MiHomeLib.Contracts;
 using MiHomeLib.MiioDevices;
-using MiHomeLib.Transport;
+
 
 namespace MiHomeLib.MqttGateway;
 

--- a/MiHomeLib/MqttGateway/MultimodeGateway2China.cs
+++ b/MiHomeLib/MqttGateway/MultimodeGateway2China.cs
@@ -3,7 +3,7 @@
 using Microsoft.Extensions.Logging;
 using MiHomeLib.Contracts;
 using MiHomeLib.MiioDevices;
-using MiHomeLib.Transport;
+
 
 namespace MiHomeLib.MqttGateway;
 

--- a/MiHomeLib/MqttGateway/MultimodeGateway2Global.cs
+++ b/MiHomeLib/MqttGateway/MultimodeGateway2Global.cs
@@ -3,7 +3,7 @@
 using Microsoft.Extensions.Logging;
 using MiHomeLib.Contracts;
 using MiHomeLib.MiioDevices;
-using MiHomeLib.Transport;
+
 
 namespace MiHomeLib.MqttGateway;
 

--- a/MiHomeLib/MqttGateway/ZigBeeTransport.cs
+++ b/MiHomeLib/MqttGateway/ZigBeeTransport.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 
 namespace MiHomeLib.MqttGateway;
 

--- a/MiHomeLib/XiaomiGateway2/Commands/ResponseCommand.cs
+++ b/MiHomeLib/XiaomiGateway2/Commands/ResponseCommand.cs
@@ -30,16 +30,16 @@ public class ResponseCommand
 
             var cmd = json["cmd"].ToString();
 
-            if (commandTypeMap.ContainsKey(cmd))
+            if (commandTypeMap.TryGetValue(cmd, out var commandType))
             {
                 return new ResponseCommand
                 {
                     RawCommand = cmd,
-                    Command = commandTypeMap[cmd],
-                    Model = json.ContainsKey("model") ? json["model"].ToString() : null,
+                    Command = commandType,
+                    Model = json.TryGetValue("model", out var model) ? model.ToString() : null,
                     Sid = json["sid"].ToString(),
-                    ShortId = json.ContainsKey("short_id") ? int.Parse(json["short_id"].ToString()) : 0,
-                    Token = json.ContainsKey("token") ? json["token"].ToString() : null,
+                    ShortId = json.TryGetValue("short_id", out var shortId) ? int.Parse(shortId.ToString()) : 0,
+                    Token = json.TryGetValue("token", out var token) ? token.ToString() : null,
                     Data = json["data"].ToString(),
                 };
             }

--- a/MiHomeLib/XiaomiGateway2/Devices/XiaomiGateway2SubDevice.cs
+++ b/MiHomeLib/XiaomiGateway2/Devices/XiaomiGateway2SubDevice.cs
@@ -5,13 +5,13 @@ using Microsoft.Extensions.Logging;
 
 namespace MiHomeLib.XiaomiGateway2.Devices;
 
-public abstract class XiaomiGateway2SubDevice(string sid, int shortId, ILoggerFactory loggerFactory)
+public abstract class XiaomiGateway2SubDevice(string sid, int shortId, ILoggerFactory loggerFactory) : GatewaySubDeviceBase(loggerFactory)
 {
-    protected readonly ILogger _logger = loggerFactory.CreateLogger<XiaomiGateway2SubDevice>();
     public string Sid { get; private set; } = sid;
     public int ShortId { get; private set; } = shortId;
+    public override string DeviceId => Sid;
     protected Dictionary<string, Action<JsonElement>> Actions = [];
-    protected internal virtual void ParseData(string data)
+    protected internal override void ParseData(string data)
     {
         LastTimeMessageReceived = DateTime.Now;
 
@@ -19,9 +19,9 @@ public abstract class XiaomiGateway2SubDevice(string sid, int shortId, ILoggerFa
 
         foreach (var prop in listProps)
         {
-            if (Actions.ContainsKey(prop.Key))
+            if (Actions.TryGetValue(prop.Key, out var action))
             {
-                Actions[prop.Key](prop.Value);
+                action(prop.Value);
             }
             else
             {
@@ -29,7 +29,5 @@ public abstract class XiaomiGateway2SubDevice(string sid, int shortId, ILoggerFa
             }
         }
     }    
-    public DateTime LastTimeMessageReceived { get; internal set; }
     public override string ToString() => $"Sid: {Sid}, Type: {GetType().Name}, Last seen: {LastTimeMessageReceived}";    
-    protected virtual string GetBaseInfo(string marketModel, string model) => $"Device: {marketModel} {model} {Sid}, ";
 }

--- a/MiHomeLib/XiaomiGateway2/XiaomiGateway2.cs
+++ b/MiHomeLib/XiaomiGateway2/XiaomiGateway2.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
+
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using MiHomeLib.Contracts;
 using MiHomeLib.MiioDevices;
-using MiHomeLib.Transport;
+
 using MiHomeLib.XiaomiGateway2.Commands;
 using MiHomeLib.XiaomiGateway2.Devices;
 
@@ -77,15 +77,9 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
 
         var gwPassword = GetDeveloperKey();
 
-        // Building map of the supported devices via reflection props 
-        foreach (Type type in Assembly
-            .GetExecutingAssembly()
-            .GetTypes()
-            .Where(x => x.IsClass && !x.IsAbstract && x.IsSubclassOf(typeof(XiaomiGateway2SubDevice))))
+        // Building map of the supported devices via reflection
+        foreach (var (type, model) in DeviceTypeScanner.FindDeviceTypes<XiaomiGateway2SubDevice>())
         {
-            var bindFlags = BindingFlags.Public | BindingFlags.Static;
-            var model = type.GetField("MODEL", bindFlags).GetValue(type).ToString();
-
             XiaomiGateway2SubDevice addDevice(string sid, int shortId) =>
                 type.IsSubclassOf(typeof(ManageableXiaomiGateway2SubDevice)) ?
                     Activator.CreateInstance(type, sid, shortId, _messageTransport, gwPassword, _loggerFactory) as ManageableXiaomiGateway2SubDevice :
@@ -139,23 +133,21 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
                     return;
                 }
 
-                if (!_supportedModels.ContainsKey(cmd.Model))
+                if (!_supportedModels.TryGetValue(cmd.Model, out var factory))
                 {
                     _logger?.LogWarning($"Model '{cmd.Model}' is not supported, please contribute to support");
                     return;
                 }
 
-                if (!_devicesList.ContainsKey(cmd.Sid))
+                if (!_devicesList.TryGetValue(cmd.Sid, out var gw2SubDevice))
                 {
-                    var supportedDevice = _supportedModels[cmd.Model](cmd.Sid, cmd.ShortId);
+                    var supportedDevice = factory(cmd.Sid, cmd.ShortId);
                     _devicesList.Add(cmd.Sid, supportedDevice);
                     supportedDevice.ParseData(cmd.Data);
 
                     await OnDeviceDiscoveredAsync(supportedDevice);
                     return;
                 }
-
-                _devicesList.TryGetValue(cmd.Sid, out var gw2SubDevice);
 
                 if (gw2SubDevice is XiaomiMultifunctionalGateway2 && cmd.Token is not null)
                 {
@@ -173,10 +165,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         _messageTransport.SendCommand(new DiscoverGatewayCommand());
     }
 
-    public void SetDeveloperKey(string key)
-    {
-        SetDeveloperKeyAsync(key).ConfigureAwait(false).GetAwaiter().GetResult();
-    }
+    public void SetDeveloperKey(string key) => RunSync(() => SetDeveloperKeyAsync(key));
 
     public async Task SetDeveloperKeyAsync(string key)
     {
@@ -190,10 +179,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         CheckMessage(await _miioTransport.SendMessageAsync(msg), "Unable to set developer key");
     }
 
-    public string GetDeveloperKey()
-    {
-        return GetDeveloperKeyAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-    }
+    public string GetDeveloperKey() => RunSync(GetDeveloperKeyAsync);
 
     public async Task<string> GetDeveloperKeyAsync()
     {
@@ -212,40 +198,28 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         return json["result"][0].ToString();
     }
 
-    public void EnableNightLight(byte r, byte g, byte b, int brightness)
-    {
-        EnableNightLightAsync(r, g, b, brightness).ConfigureAwait(false).GetAwaiter().GetResult();
-    }
+    public void EnableNightLight(byte r, byte g, byte b, int brightness) => RunSync(() => EnableNightLightAsync(r, g, b, brightness));
 
     public async Task EnableNightLightAsync(byte r, byte g, byte b, int brightness)
     {
         await SetLightAsync("set_night_light_rgb", r, g, b, brightness);
     }
 
-    public void DisableNightLight()
-    {
-        DisableNightLightAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-    }
+    public void DisableNightLight() => RunSync(DisableNightLightAsync);
 
     public async Task DisableNightLightAsync()
     {
         await SetLightAsync("set_night_light_rgb", 0, 0, 0, 0);
     }
 
-    public void EnableLight(byte r, byte g, byte b, int brightness)
-    {
-        EnableLightAsync(r, g, b, brightness).ConfigureAwait(false).GetAwaiter().GetResult();
-    }
+    public void EnableLight(byte r, byte g, byte b, int brightness) => RunSync(() => EnableLightAsync(r, g, b, brightness));
 
     public async Task EnableLightAsync(byte r, byte g, byte b, int brightness)
     {
         await SetLightAsync("set_rgb", r, g, b, brightness);
     }
 
-    public void DisableLight()
-    {
-        DisableLightAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-    }
+    public void DisableLight() => RunSync(DisableLightAsync);
 
     public async Task DisableLightAsync()
     {
@@ -263,10 +237,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         CheckMessage(await _miioTransport.SendMessageAsync(msg), $"Unable to send command '{dayOrNight}' with {rgb} and {brightness}");
     }
 
-    public void PlaySound(Sound sound, int volume)
-    {
-        PlaySoundAsync(sound, volume).ConfigureAwait(false).GetAwaiter().GetResult();
-    }
+    public void PlaySound(Sound sound, int volume) => RunSync(() => PlaySoundAsync(sound, volume));
 
     public async Task PlaySoundAsync(Sound sound, int volume)
     {
@@ -275,20 +246,14 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         CheckMessage(await _miioTransport.SendMessageAsync(msg), $"Unable to play sound {sound}");
     }
 
-    public void SoundsOff()
-    {
-        SoundsOffAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-    }
+    public void SoundsOff() => RunSync(SoundsOffAsync);
 
     public async Task SoundsOffAsync()
     {
         await PlaySoundAsync(0, 0);
     }
 
-    public void PlayCustomSound(int soundNo, int volume)
-    {
-        PlayCustomSoundAsync(soundNo, volume).ConfigureAwait(false).GetAwaiter().GetResult();
-    }
+    public void PlayCustomSound(int soundNo, int volume) => RunSync(() => PlayCustomSoundAsync(soundNo, volume));
     public async Task PlayCustomSoundAsync(int soundNo, int volume)
     {
         if (soundNo <= 10_000) throw new ArgumentException("Custom sounds must start from 10001");
@@ -298,12 +263,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         CheckMessage(await _miioTransport.SendMessageAsync(msg), $"Unable to play custom sound {soundNo}");
     }
 
-    public bool IsArmingOn()
-    {
-        var msg = _miioTransport.SendMessage(BuildParamsArray("get_arming", []));
-
-        return CheckArmingState(msg);
-    }
+    public bool IsArmingOn() => RunSync(IsArmingOnAsync);
 
     public async Task<bool> IsArmingOnAsync()
     {
@@ -327,12 +287,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         return result == "on";
     }
 
-    public void SetArmingOff()
-    {
-        var msg = BuildParamsArray("set_arming", "off");
-        var result = _miioTransport.SendMessage(msg);
-        CheckMessage(result, "Unable to set arming off");
-    }
+    public void SetArmingOff() => RunSync(SetArmingOffAsync);
 
     public async Task SetArmingOffAsync()
     {
@@ -341,12 +296,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         CheckMessage(result, "Unable to set arming off");
     }
 
-    public void SetArmingOn()
-    {
-        var msg = BuildParamsArray("set_arming", "on");
-        var result = _miioTransport.SendMessage(msg);
-        CheckMessage(result, "Unable to set arming on");
-    }
+    public void SetArmingOn() => RunSync(SetArmingOnAsync);
 
     public async Task SetArmingOnAsync()
     {
@@ -355,12 +305,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         CheckMessage(result, "Unable to set arming on");
     }
 
-    public int GetArmingWaitTime()
-    {
-        var msg = BuildParamsArray("get_arm_wait_time", new string[0]);
-        var result = _miioTransport.SendMessage(msg);
-        return CheckArmingWaitResult(result);
-    }
+    public int GetArmingWaitTime() => RunSync(GetArmingWaitTimeAsync);
 
     public async Task<int> GetArmingWaitTimeAsync()
     {
@@ -374,12 +319,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         return GetInteger(result, "Unable to get arming wait time");
     }
 
-    public void SetArmingWaitTime(int seconds)
-    {
-        var msg = BuildParamsArray("set_arm_wait_time", seconds);
-        var result = _miioTransport.SendMessage(msg);
-        CheckMessage(result, "Unable to set arming wait time");
-    }
+    public void SetArmingWaitTime(int seconds) => RunSync(() => SetArmingWaitTimeAsync(seconds));
 
     public async Task SetArmingWaitTimeAsync(int seconds)
     {
@@ -388,12 +328,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         CheckMessage(result, "Unable to set arming wait time");
     }
 
-    public int GetArmingOffTime()
-    {
-        var msg = BuildParamsArray("get_device_prop", "lumi.0", "alarm_time_len");
-        var result = _miioTransport.SendMessage(msg);
-        return CheckArmingOffTimeResult(result);
-    }
+    public int GetArmingOffTime() => RunSync(GetArmingOffTimeAsync);
 
     public async Task<int> GetArmingOffTimeAsync()
     {
@@ -407,12 +342,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         return GetInteger(result, "Unable to get arming off time");
     }
 
-    public void SetArmingOffTime(int seconds)
-    {
-        var msg = BuildSidProp("set_device_prop", "lumi.0", "alarm_time_len", seconds);
-        var result = _miioTransport.SendMessage(msg);
-        CheckMessage(result, "Unable to set arming off time");
-    }
+    public void SetArmingOffTime(int seconds) => RunSync(() => SetArmingOffTimeAsync(seconds));
 
     public async Task SetArmingOffTimeAsync(int seconds)
     {
@@ -421,12 +351,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         CheckMessage(result, "Unable to set arming off time");
     }
 
-    public int GetArmingBlinkingTime()
-    {
-        var msg = BuildParamsArray("get_device_prop", "lumi.0", "en_alarm_light");
-        var result = _miioTransport.SendMessage(msg);
-        return CheckArmingBlinkingResult(result);
-    }
+    public int GetArmingBlinkingTime() => RunSync(GetArmingBlinkingTimeAsync);
 
     public async Task<int> GetArmingBlinkingTimeAsync()
     {
@@ -440,12 +365,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         return GetInteger(result, "Unable to get arming blinking time");
     }
 
-    public void SetArmingBlinkingTime(int seconds)
-    {
-        var msg = BuildSidProp("set_device_prop", "lumi.0", "en_alarm_light", seconds);
-        var result = _miioTransport.SendMessage(msg);
-        CheckMessage(result, "Unable to set arming blinking time");
-    }
+    public void SetArmingBlinkingTime(int seconds) => RunSync(() => SetArmingBlinkingTimeAsync(seconds));
 
     public async Task SetArmingBlinkingTimeAsync(int seconds)
     {
@@ -454,12 +374,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         CheckMessage(result, "Unable to set arming blinking time");
     }
 
-    public int GetArmingVolume()
-    {
-        var msg = BuildParamsArray("get_alarming_volume", []);
-        var result = _miioTransport.SendMessage(msg);
-        return CheckArmingVolumeResult(result);
-    }
+    public int GetArmingVolume() => RunSync(GetArmingVolumeAsync);
 
     public async Task<int> GetArmingVolumeAsync()
     {
@@ -473,12 +388,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         return GetInteger(result, "Unable to get arming volume level");
     }
 
-    public void SetArmingVolume(int volume)
-    {
-        var msg = BuildParamsArray("set_alarming_volume", volume);
-        var result = _miioTransport.SendMessage(msg);
-        CheckMessage(result, "Unable to set arming volume level");
-    }
+    public void SetArmingVolume(int volume) => RunSync(() => SetArmingVolumeAsync(volume));
 
     public async Task SetArmingVolumeAsync(int volume)
     {
@@ -491,12 +401,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
     /// Get last time when alarm was triggered unix timestamp 
     /// </summary>
     /// <returns>unix timestamp seconds</returns>
-    public int GetArmingLastTimeTriggeredTimestamp()
-    {
-        var msg = BuildParamsArray("get_arming_time", []);
-        var result = _miioTransport.SendMessage(msg);
-        return CheckArmingLastTimeTriggeredResult(result);
-    }
+    public int GetArmingLastTimeTriggeredTimestamp() => RunSync(GetArmingLastTimeTriggeredTimestampAsync);
 
     /// <summary>
     /// Get last time when alarm was triggered unix timestamp 
@@ -518,13 +423,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
     /// Get list or radio channels from gateway in format {id: <int>, url: <url>}
     /// </summary>
     /// <returns>List of RadioChannel</returns>
-    public List<RadioChannel> GetRadioChannels()
-    {
-        var response = _miioTransport.SendMessage(BuildParamsObject("get_channels", new { start = 0 }));
-        var channelsJson = JsonNode.Parse(response)["result"]["chs"].ToString();
-        var radioChannels = JsonSerializer.Deserialize<List<RadioChannel>>(channelsJson, new JsonSerializerOptions() { PropertyNameCaseInsensitive = true });
-        return [.. radioChannels];
-    }
+    public List<RadioChannel> GetRadioChannels() => RunSync(GetRadioChannelsAsync);
 
     /// <summary>
     /// Get list or radio channels from gateway in format {id: <int>, url: <url>}
@@ -540,18 +439,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
     /// <summary>
     /// Add custom radio channel to the gateway
     /// </summary>
-    public void AddRadioChannel(int channelId, string channelUrl)
-    {
-        if (channelId < 1024) throw new ArgumentException($"Radio channel id must be > 1024");
-
-        if (GetRadioChannels().Any(x => x.Id == channelId))
-            throw new ArgumentException($"Radio channel with id {channelId} already exists, choose another id");
-
-        var msg = BuildParamsObject("add_channels", new { chs = new List<RadioChannel> { new() { Id = channelId, Url = channelUrl, Type = 0 } } });
-        var result = _miioTransport.SendMessage(msg);
-
-        CheckMessage(result, "Unable to add radio channel");
-    }
+    public void AddRadioChannel(int channelId, string channelUrl) => RunSync(() => AddRadioChannelAsync(channelId, channelUrl));
 
     /// <summary>
     /// Add custom radio channel to the gateway
@@ -572,20 +460,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
     /// <summary>
     /// Remove custom radio channel from gateway stations list
     /// </summary>
-    public void RemoveRadioChannel(int channelId)
-    {
-        var radioChannels = GetRadioChannels();
-
-        if (!radioChannels.Any(x => x.Id == channelId))
-            throw new ArgumentException($"Radio channel with id {channelId} doesn't exist");
-
-        radioChannels.RemoveAll(x => x.Id != channelId);
-
-        var msg = BuildParamsObject("remove_channels", new { chs = radioChannels });
-        var result = _miioTransport.SendMessage(msg);
-
-        CheckMessage(result, $"Unable to remove radio channel with id {channelId}");
-    }
+    public void RemoveRadioChannel(int channelId) => RunSync(() => RemoveRadioChannelAsync(channelId));
 
     /// <summary>
     /// Remove custom radio channel from gateway stations list
@@ -608,13 +483,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
     /// <summary>
     /// Clear all custom radio channels from the gateway
     /// </summary>
-    public void RemoveAllRadioChannels()
-    {
-        var radioChannels = GetRadioChannels();
-        var msg = BuildParamsObject("remove_channels", new { chs = radioChannels });
-        var result = _miioTransport.SendMessage(msg);
-        CheckMessage(result, "Unable to remove all radio channels");
-    }
+    public void RemoveAllRadioChannels() => RunSync(RemoveAllRadioChannelsAsync);
 
     /// <summary>
     /// Clear all custom radio channels from the gateway
@@ -630,17 +499,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
     /// <summary>
     /// Start playing custom channel
     /// </summary>
-    public void PlayRadio(int channelId, int volume)
-    {
-        if (volume < 0 || volume > 100)
-            throw new ArgumentException($"Volume must be within range 0-100");
-
-        if (!GetRadioChannels().Any(x => x.Id == channelId))
-            throw new ArgumentException($"Radio channel with id {channelId} doesn't exist");
-
-        var result = _miioTransport.SendMessage(BuildParamsArray("play_specify_fm", channelId, volume));
-        CheckMessage(result, $"Unable to play channelId: {channelId} with volume {volume}");
-    }
+    public void PlayRadio(int channelId, int volume) => RunSync(() => PlayRadioAsync(channelId, volume));
 
     /// <summary>
     /// Start playing custom channel
@@ -660,11 +519,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
     /// <summary>
     /// Stop playing radio
     /// </summary>
-    public void StopRadio()
-    {
-        var result = _miioTransport.SendMessage(BuildParamsArray("play_fm", "off"));
-        CheckMessage(result, $"Unable to stop playing radio");
-    }
+    public void StopRadio() => RunSync(StopRadioAsync);
 
     /// <summary>
     /// Stop playing radio
@@ -703,7 +558,7 @@ public class XiaomiGateway2 : MiioDevice, IDisposable
         }
     }
 
-    public new void Dispose()
+    public override void Dispose()
     {
         _messageTransport?.Dispose();
         base.Dispose();

--- a/MiHomeUnitTests/MiioDeviceBase.cs
+++ b/MiHomeUnitTests/MiioDeviceBase.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using MiHomeLib;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 using Moq;
 
 namespace MiHomeUnitTests;

--- a/MiHomeUnitTests/MqttGatewayBaseTests.cs
+++ b/MiHomeUnitTests/MqttGatewayBaseTests.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MiHomeLib;
+using MiHomeLib.Contracts;
 using MiHomeLib.MqttGateway;
 using MiHomeLib.MqttGateway.JsonResponses;
 using MiHomeLib.MqttGateway.Devices;
@@ -85,7 +86,7 @@ public class MqttGatewayBaseTests : MqttGatewayDeviceTests
 
         _devicesDiscoverer
             .Setup(x => x.DiscoverZigBeeDevices())
-            .Returns(devices.Select(x => (x.did, x.model)).ToList());
+            .Returns(devices.Select(x => new ZigBeeDeviceInfo(x.did, x.model)).ToList());
     }
     private void SetupZigBeeMiSpecDevices(List<(string did, string model)> devices)
     {
@@ -105,13 +106,13 @@ public class MqttGatewayBaseTests : MqttGatewayDeviceTests
 
         _devicesDiscoverer
             .Setup(x => x.DiscoverZigBeeDevices())
-            .Returns(devices.Select(x => (x.did, x.model)).ToList());
+            .Returns(devices.Select(x => new ZigBeeDeviceInfo(x.did, x.model)).ToList());
     }
     private void SetupBleDevices(List<(string did, int pdid, string mac)> devices)
     {
         _devicesDiscoverer
             .Setup(x => x.DiscoverBleDevices())
-            .Returns(devices);
+            .Returns(devices.Select(x => new BleDeviceInfo(x.did, x.pdid, x.mac)).ToList());
     }
     private void RaiseZigbeeReportEvent(string did, double time, List<(string res, int value)> props)
     {

--- a/MiHomeUnitTests/MultimodeGatewaySubDevicesTests/MqttGatewayDeviceTests.cs
+++ b/MiHomeUnitTests/MultimodeGatewaySubDevicesTests/MqttGatewayDeviceTests.cs
@@ -8,7 +8,7 @@ using Microsoft.Extensions.Logging.Abstractions;
 using MiHomeLib;
 using MiHomeLib.Contracts;
 using MiHomeLib.MqttGateway.JsonResponses;
-using MiHomeLib.Transport;
+
 using Moq;
 using static MiHomeLib.MqttGateway.JsonResponses.BleAsyncEventResponse;
 using static MiHomeLib.MqttGateway.JsonResponses.BleAsyncEventResponse.BleAsyncEventParams;

--- a/MiHomeUnitTests/XiaomiGateway2Tests.cs
+++ b/MiHomeUnitTests/XiaomiGateway2Tests.cs
@@ -6,7 +6,7 @@ using MiHomeLib.XiaomiGateway2;
 using MiHomeLib.XiaomiGateway2.Devices;
 using MiHomeLib.XiaomiGateway2.Commands;
 using System.Threading.Tasks;
-using MiHomeLib.Transport;
+using MiHomeLib.Contracts;
 using System;
 using System.Text.Json;
 using System.Linq;
@@ -309,13 +309,13 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void IsArmingOn_Returns_Arming_State()
     {
         // Arrange
-        SendResultMethod(string.Empty, ["on"]);
+        SendResultMethodAsync(string.Empty, ["on"]);
         
         // Act
         var arming = _gateway.IsArmingOn();
 
         // Assert
-        VerifyMethod("get_arming", []);        
+        VerifyMethodAsync("get_arming", Array.Empty<string>());
         arming.Should().BeTrue();
     }
 
@@ -337,13 +337,13 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void SetArmingOn_Should_Not_Throw_Exceptions()
     {
         // Arrange
-        SendResultMethod(string.Empty, ["ok"]);
+        SendResultMethodAsync(string.Empty, ["ok"]);
 
         // Act
         _gateway.SetArmingOn();
 
         // Assert
-        VerifyMethod("set_arming", ["on"]);
+        VerifyMethodAsync("set_arming", ["on"]);
     }
 
     [Fact]
@@ -363,13 +363,13 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void SetArmingOff_Should_Not_Throw_Exceptions()
     {
         // Arrange
-        SendResultMethod(string.Empty, ["ok"]);
+        SendResultMethodAsync(string.Empty, ["ok"]);
         
         // Act
         _gateway.SetArmingOff();
 
         // Assert
-        VerifyMethod("set_arming", ["off"]);
+        VerifyMethodAsync("set_arming", ["off"]);
     }
 
     [Fact]
@@ -389,13 +389,13 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void GetArmingWaitTime_Returns_Integer()
     {
         // Arrange
-        SendResultMethod(string.Empty, [15]);
+        SendResultMethodAsync(string.Empty, [15]);
         
         // Act
         var armingWaitTime = _gateway.GetArmingWaitTime();
 
         // Assert
-        VerifyMethod("get_arm_wait_time",[]);
+        VerifyMethodAsync("get_arm_wait_time", []);
 
         armingWaitTime.Should().Be(15);
     }
@@ -418,13 +418,13 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void SetArmingWaitTime_Should_Not_Throw_Exceptions()
     {
         // Arrange
-        SendResultMethod(string.Empty, ["ok"]);
+        SendResultMethodAsync(string.Empty, ["ok"]);
         
         // Act
         _gateway.SetArmingWaitTime(20);
 
         // Assert
-        VerifyMethod("set_arm_wait_time", [20]);
+        VerifyMethodAsync("set_arm_wait_time", [20]);
     }
 
     [Fact]
@@ -444,13 +444,13 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void GetArmingOffTime_Returns_Integer()
     {
         // Arrange
-        SendResultMethod(string.Empty, [15]);
+        SendResultMethodAsync(string.Empty, [15]);
         
         // Act
         var armingOffTime = _gateway.GetArmingOffTime();
 
         // Assert
-        VerifyMethod("get_device_prop", ["lumi.0", "alarm_time_len"]);
+        VerifyMethodAsync("get_device_prop", ["lumi.0", "alarm_time_len"]);
         armingOffTime.Should().Be(15);
     }
 
@@ -472,14 +472,14 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void SetArmingOffTime_Should_Not_Throw_Exceptions()
     {
         // Arrange
-        SendResultMethod(string.Empty, ["ok"]);
+        SendResultMethodAsync(string.Empty, ["ok"]);
         
         // Act
         _gateway.SetArmingOffTime(40);
 
         // Assert
         _miioTransport
-            .Verify(x => x.SendMessage(new
+            .Verify(x => x.SendMessageAsync(new
             {
                 id = 1,
                 method = "set_device_prop",
@@ -510,13 +510,13 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void GetArmingBlinkingTime_Returns_Integer()
     {
         // Arrange
-        SendResultMethod(string.Empty, [15]);
+        SendResultMethodAsync(string.Empty, [15]);
         
         // Act
         var armingBlinkingTime = _gateway.GetArmingBlinkingTime();
 
         // Assert
-        VerifyMethod("get_device_prop", ["lumi.0", "en_alarm_light"]);        
+        VerifyMethodAsync("get_device_prop", ["lumi.0", "en_alarm_light"]);
         armingBlinkingTime.Should().Be(15);
     }
 
@@ -538,14 +538,14 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void SetArmingBlinkingTime_Should_Not_Throw_Exceptions()
     {
         // Arrange
-        SendResultMethod(string.Empty, ["ok"]);
+        SendResultMethodAsync(string.Empty, ["ok"]);
         
         // Act
         _gateway.SetArmingBlinkingTime(40);
 
         // Assert
         _miioTransport
-            .Verify(x => x.SendMessage(new
+            .Verify(x => x.SendMessageAsync(new
             {
                 id = 1,
                 method = "set_device_prop",
@@ -576,13 +576,13 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void GetArmingVolume_Returns_Integer()
     {
         // Arrange
-        SendResultMethod(string.Empty, [10]);
+        SendResultMethodAsync(string.Empty, [10]);
         
         // Act
         var armingVolume = _gateway.GetArmingVolume();
 
         // Assert
-        VerifyMethod("get_alarming_volume", []);        
+        VerifyMethodAsync("get_alarming_volume", []);
         armingVolume.Should().Be(10);
     }
 
@@ -604,13 +604,13 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void SetArmingVolume_Should_Not_Throw_Exceptions()
     {
         // Arrange
-        SendResultMethod(string.Empty, ["ok"]);
+        SendResultMethodAsync(string.Empty, ["ok"]);
         
         // Act
         _gateway.SetArmingVolume(15);
 
         // Assert
-        VerifyMethod("set_alarming_volume", [15]);
+        VerifyMethodAsync("set_alarming_volume", [15]);
     }
 
     [Fact]
@@ -630,13 +630,13 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void GetArmingLastTimeTriggeredTimestamp_Returns_Integer()
     {
         // Arrange
-        SendResultMethod(string.Empty, [1609150074]);        
+        SendResultMethodAsync(string.Empty, [1609150074]);
         
         // Act
         var timestamp = _gateway.GetArmingLastTimeTriggeredTimestamp();
 
         // Assert
-        VerifyMethod("get_arming_time", []);
+        VerifyMethodAsync("get_arming_time", []);
         timestamp.Should().Be(1609150074);
     }
 
@@ -659,15 +659,15 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     {
         // Arrange
         _miioTransport
-            .Setup(x => x.SendMessage(It.IsAny<string>()))
-            .Returns(ToRadioListJson([1025, 1026, 1027]));
+            .Setup(x => x.SendMessageAsync(It.IsAny<string>()))
+            .Returns(Task.FromResult(ToRadioListJson([1025, 1026, 1027])));
 
         // Act
         var radioChannels = _gateway.GetRadioChannels();
 
         // Assert
         _miioTransport
-            .Verify(x => x.SendMessage(new
+            .Verify(x => x.SendMessageAsync(new
             {
                 id = 1,
                 method = "get_channels",
@@ -715,8 +715,8 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     {
         // Arrange
         _miioTransport
-            .Setup(x => x.SendMessage(It.IsAny<string>()))
-            .Returns(ToRadioListJson([1025, 1045, 1027]));
+            .Setup(x => x.SendMessageAsync(It.IsAny<string>()))
+            .Returns(Task.FromResult(ToRadioListJson([1025, 1045, 1027])));
 
         // Act
         var actual = _gateway.Invoking(x => x.AddRadioChannel(1045, "http://192.168.1.1/radio.m3u8"));
@@ -729,20 +729,17 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     {
         // Arrange
         _miioTransport
-            .Setup(x => x.SendMessage(It.Is<string>(s => s.Contains("get_channels"))))
-            .Returns(ToRadioListJson([1025, 1026, 1027]));
+            .Setup(x => x.SendMessageAsync(It.Is<string>(s => s.Contains("get_channels"))))
+            .Returns(Task.FromResult(ToRadioListJson([1025, 1026, 1027])));
 
-        SendResultMethod("add_channels", ["ok"]);
-        // _miioTransport
-        //     .Setup(x => x.SendMessage(It.Is<string>(s => s.Contains("add_channels"))))
-        //     .Returns(ResultOkJson(2));
+        SendResultMethodAsync("add_channels", ["ok"]);
 
         // Act
         _gateway.AddRadioChannel(1045, "http://192.168.1.1/radio4.m3u8");
 
         // Assert
         _miioTransport
-            .Verify(x => x.SendMessage(new
+            .Verify(x => x.SendMessageAsync(new
             {
                 id = 2,
                 method = "add_channels",
@@ -778,8 +775,8 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     {
         // Arrange
         _miioTransport
-            .Setup(x => x.SendMessage(It.Is<string>(s => s.Contains("get_channels"))))
-            .Returns(ToRadioListJson([1025, 1026, 1027]));
+            .Setup(x => x.SendMessageAsync(It.Is<string>(s => s.Contains("get_channels"))))
+            .Returns(Task.FromResult(ToRadioListJson([1025, 1026, 1027])));
 
         // Act
         var actual = _gateway.Invoking(x => x.RemoveRadioChannel(1045));
@@ -793,17 +790,17 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     {
         // Arrange
         _miioTransport
-            .Setup(x => x.SendMessage(It.Is<string>(s => s.Contains("get_channels"))))
-            .Returns(ToRadioListJson([1025, 1026, 1027]));
+            .Setup(x => x.SendMessageAsync(It.Is<string>(s => s.Contains("get_channels"))))
+            .Returns(Task.FromResult(ToRadioListJson([1025, 1026, 1027])));
 
-        SendResultMethod("remove_channels", ["ok"]);
+        SendResultMethodAsync("remove_channels", ["ok"]);
 
         // Act
         _gateway.RemoveRadioChannel(1027);
 
         // Assert
         _miioTransport
-            .Verify(x => x.SendMessage(new
+            .Verify(x => x.SendMessageAsync(new
             {
                 id = 2,
                 method = "remove_channels",
@@ -839,21 +836,21 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     {
         // Arrange
         _miioTransport
-            .Setup(x => x.SendMessage(It.Is<string>(s => s.Contains("get_channels"))))
-            .Returns(ToRadioListJson([1025, 1026, 1027]));
+            .Setup(x => x.SendMessageAsync(It.Is<string>(s => s.Contains("get_channels"))))
+            .Returns(Task.FromResult(ToRadioListJson([1025, 1026, 1027])));
 
-        SendResultMethod("remove_channels", ["ok"]);
+        SendResultMethodAsync("remove_channels", ["ok"]);
 
         // Act
         _gateway.RemoveAllRadioChannels();
 
         // Assert
         _miioTransport
-            .Verify(x => x.SendMessage(new
+            .Verify(x => x.SendMessageAsync(new
             {
                 id = 2,
                 method = "remove_channels",
-                @params = new { chs = new[] 
+                @params = new { chs = new[]
                 {
                     new { id = 1025, url = "http://192.168.1.1/radio1025.m3u8", type = 0 },
                     new { id = 1026, url = "http://192.168.1.1/radio1026.m3u8", type = 0 },
@@ -904,8 +901,8 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     {
         // Arrange
         _miioTransport
-            .Setup(x => x.SendMessage(It.Is<string>(s => s.Contains("get_channels"))))
-            .Returns(ToRadioListJson([1025, 1026, 1027]));
+            .Setup(x => x.SendMessageAsync(It.Is<string>(s => s.Contains("get_channels"))))
+            .Returns(Task.FromResult(ToRadioListJson([1025, 1026, 1027])));
 
         // Act
         var actual = _gateway.Invoking(x => x.PlayRadio(1045, 50));
@@ -919,17 +916,17 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     {
         // Arrange
         _miioTransport
-            .Setup(x => x.SendMessage(It.Is<string>(s => s.Contains("get_channels"))))
-            .Returns(ToRadioListJson([1025, 1026, 1027]));
+            .Setup(x => x.SendMessageAsync(It.Is<string>(s => s.Contains("get_channels"))))
+            .Returns(Task.FromResult(ToRadioListJson([1025, 1026, 1027])));
 
-        SendResultMethod("play_specify_fm", ["ok"]);
+        SendResultMethodAsync("play_specify_fm", ["ok"]);
 
         // Act
         _gateway.PlayRadio(1027, 50);
 
         // Assert
          _miioTransport
-            .Verify(x => x.SendMessage(new
+            .Verify(x => x.SendMessageAsync(new
             {
                 id = 2,
                 method = "play_specify_fm",
@@ -964,13 +961,13 @@ public class XiaomiGateway2Tests: Gw2DeviceTests
     public void StopRadio_Should_Not_Throw_Exceptions()
     {
         // Arrange
-        SendResultMethod("play_fm", ["ok"]);
+        SendResultMethodAsync("play_fm", ["ok"]);
 
         // Act
         _gateway.StopRadio();
 
         // Assert
-        VerifyMethod("play_fm", ["off"]);
+        VerifyMethodAsync("play_fm", ["off"]);
     }
 
     [Fact]


### PR DESCRIPTION
1. Unify namespace for contracts - move IMiioTransport and IMqttTransport from MiHomeLib.Transport to MiHomeLib.Contracts

2. Extract GatewaySubDeviceBase from MqttGatewaySubDevice and XiaomiGateway2SubDevice with shared members: _logger, LastTimeMessageReceived, ParseData, DeviceId, GetBaseInfo

3. Add RunSync/RunSync<T> helpers to MiioDevice and eliminate sync/async boilerplate in XiaomiGateway2 (~130 lines reduced)

4. Extract DeviceTypeScanner to eliminate duplicated reflection-based device registration in MqttGatewayBase and XiaomiGateway2

5. Fix Dispose pattern - make MiioDevice.Dispose() virtual, change MqttGatewayBase and XiaomiGateway2 from 'new' to 'override'

6. Replace value tuples with typed BleDeviceInfo/ZigBeeDeviceInfo classes in IDevicesDiscoverer interface

7. Replace ContainsKey + indexer with TryGetValue across 12 files

8. Fix broken message ID update in RepeatMessageIfTimeout

9. Improve exception handling: capture last exception in retry methods, narrow catch clause in SendDiscoverMessage to SocketException only